### PR TITLE
Set the attribute chunksize as passed in, not zero

### DIFF
--- a/src/libkea/KEAImageIO.cpp
+++ b/src/libkea/KEAImageIO.cpp
@@ -3400,7 +3400,7 @@ namespace kealib{
             keaImgH5File->createGroup( bandName+KEA_ATT_GROUPNAME_HEADER );
 
             // SET ATTRIBUTE TABLE CHUNK SIZE
-            int attChunkSize = 0;
+            int attChunkSize = attBlockSize;
             hsize_t dimsAttChunkSize[] = { 1 };
             H5::DataSpace attChunkSizeDataSpace(1, dimsAttChunkSize);
             H5::DataSet attChunkSizeDataset = keaImgH5File->createDataSet((bandName+KEA_ATT_CHUNKSIZE_HEADER), H5::PredType::STD_U64LE, attChunkSizeDataSpace);


### PR DESCRIPTION
@petebunting this seems like a bug, but I'm not sure. Seems zero was always getting written for this, and being used when attributes created etc. Not sure what the effect was as it seemed like it was working...

Anyway, keen to hear you thoughts :smile: 

cc: @petescarth @danclewley