### PR TITLE
print error on open failure

### DIFF
--- a/gdal/keadataset.cpp
+++ b/gdal/keadataset.cpp
@@ -141,6 +141,9 @@ GDALDataset *KEADataset::Open( GDALOpenInfo * poOpenInfo )
         catch (kealib::KEAIOException &e)
         {
             // was a problem - can't be a valid file
+            CPLError( CE_Failure, CPLE_OpenFailed,
+                  "Attempt to open file `%s' failed. Error: %s\n",
+                  poOpenInfo->pszFilename, e.what() );
             return NULL;
         }
     }


### PR DESCRIPTION
Previously, `gdal.Open` would return None but no message gets printed to tell the user what's going on. This PR doesn't give much more info but at least they now get something like this printed to the console:

```
RuntimeError: Attempt to open file `mask.kea' failed. Error: H5Fopen failed
```