### PR TITLE
.deb package building for ubuntugis 20.04

### DIFF
--- a/contrib/ubuntu/README.md
+++ b/contrib/ubuntu/README.md
@@ -7,3 +7,10 @@ Run the following command **from the root of the repository**
 This creates a docker image which should have the debian built in /usr/local/packages from where you can copy it out, e.g.,
 
 `docker run --rm --entrypoint cat kealib_deb_builder /usr/local/packages/libkea_1.4.14-1.deb > /tmp/libkea_1.4.14-1.deb`
+
+## Hosted Packages (Use at own risk!)
+
+Environment Systems Ltd host some packages built as above for convenience:
+
+ - https://envsys-public.s3.amazonaws.com/ubuntu/kealib/focal_ubuntugis_stable_libkea_1.4.14-1.deb
+ - https://envsys-public.s3.amazonaws.com/ubuntu/kealib/focal_ubuntugis_unstable_libkea_1.4.14-1.deb

--- a/contrib/ubuntu/README.md
+++ b/contrib/ubuntu/README.md
@@ -1,0 +1,9 @@
+# To build .deb packages
+
+Run the following command **from the root of the repository**
+
+`docker build . -f contrib/ubuntu/focal_ubuntugis_stable/Dockerfile -t kealib_deb_builder`
+
+This creates a docker image which should have the debian built in /usr/local/packages from where you can copy it out, e.g.,
+
+`docker run --rm --entrypoint cat kealib_deb_builder /usr/local/packages/libkea_1.4.14-1.deb > /tmp/libkea_1.4.14-1.deb`

--- a/contrib/ubuntu/focal_ubuntugis_stable/DEBIAN/control
+++ b/contrib/ubuntu/focal_ubuntugis_stable/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: libkea
+Version: 1.4.14-1
+Section: science
+Priority: optional
+Architecture: amd64
+Depends: libgdal29, libhdf5-cpp-103, libproj19
+Maintainer: Environment Systems Ltd. (developers@envsys.co.uk)
+Description: An HDF5 Based Raster File Format
+  KEALib provides an implementation of the GDAL data model. The format supports raster attribute tables, image pyramids, meta-data and in-built statistics while also handling very large files and compression throughout.
+ Based on the HDF5 standard, it also provides a base from which other formats can be derived and is a good choice for long term data archiving. An independent software library (libkea) provides complete access to the KEA image format and a GDAL driver allowing KEA images to be used from any GDAL supported software.
+ Development work on this project has been funded by Landcare Research. For more information see http://kealib.org

--- a/contrib/ubuntu/focal_ubuntugis_stable/Dockerfile
+++ b/contrib/ubuntu/focal_ubuntugis_stable/Dockerfile
@@ -1,0 +1,59 @@
+#
+# This creates an Ubuntu derived base image to build
+# Kealib and package it as .deb
+# 
+# NOTE: The built package is designed to work on ubuntu focal with ubuntu-gis stable PPA
+# This is for the updated gdal versions available within that PPA.
+#
+# Ubuntu 20.04 Bionic Beaver
+FROM ubuntu:focal
+
+MAINTAINER EnvSys <developers@envsys.co.uk>
+
+ENV ROOTDIR /usr/local/
+
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Load assets
+WORKDIR $ROOTDIR/
+
+# Install basic dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository -y ppa:ubuntugis/ppa && \
+    apt-get update -y && apt-get install --no-install-recommends -y \
+    build-essential \
+    libgdal-dev \
+    libhdf5-dev \
+    cmake
+
+ARG KEALIB_VER=1.4.14
+ARG PACKAGE_DIR=/usr/local/packages
+ARG KEALIB_PACKAGE_DIR=$PACKAGE_DIR/libkea_$KEALIB_VER-1
+ARG make_threads=7
+
+RUN mkdir /usr/local/src/kealib
+COPY . /usr/local/src/kealib
+
+RUN mkdir -p $KEALIB_PACKAGE_DIR/DEBIAN && mkdir -p $KEALIB_PACKAGE_DIR/etc/profile.d
+
+# Install kealib
+RUN cd /usr/local/src/kealib && \
+    cmake \
+    -D CMAKE_VERBOSE_MAKEFILE=ON \
+    -D HDF5_INCLUDE_DIR=/usr/include/hdf5/serial \
+    -D GDAL_INCLUDE_DIR=/usr/include/gdal \
+    -D LIBKEA_WITH_GDAL=ON \
+    -D BUILD_SHARED_LIBS=ON \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    . && \
+    make -j "${make_threads}" && \
+    make install DESTDIR=$KEALIB_PACKAGE_DIR && \
+    echo export GDAL_DRIVER_PATH=/usr/lib/gdalplugins >> $KEALIB_PACKAGE_DIR/etc/profile.d/kealib.sh
+   
+COPY ./contrib/ubuntu/focal_ubuntugis_stable/DEBIAN $KEALIB_PACKAGE_DIR/DEBIAN
+RUN dpkg-deb --build $KEALIB_PACKAGE_DIR
+RUN echo "The package is built and is available in the image in $PACKAGE_DIR"

--- a/contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN/control
+++ b/contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: libkea
+Version: 1.4.14-1
+Section: science
+Priority: optional
+Architecture: amd64
+Depends: libgdal30, libhdf5-cpp-103, libproj22
+Maintainer: Environment Systems Ltd. (developers@envsys.co.uk)
+Description: An HDF5 Based Raster File Format
+  KEALib provides an implementation of the GDAL data model. The format supports raster attribute tables, image pyramids, meta-data and in-built statistics while also handling very large files and compression throughout.
+ Based on the HDF5 standard, it also provides a base from which other formats can be derived and is a good choice for long term data archiving. An independent software library (libkea) provides complete access to the KEA image format and a GDAL driver allowing KEA images to be used from any GDAL supported software.
+ Development work on this project has been funded by Landcare Research. For more information see http://kealib.org

--- a/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
+++ b/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
@@ -1,0 +1,59 @@
+#
+# This creates an Ubuntu derived base image to build
+# Kealib and package it as .deb
+# 
+# NOTE: The built package is designed to work on ubuntu focal with ubuntu-gis stable PPA
+# This is for the updated gdal versions available within that PPA.
+#
+# Ubuntu 20.04 Bionic Beaver
+FROM ubuntu:focal
+
+MAINTAINER EnvSys <developers@envsys.co.uk>
+
+ENV ROOTDIR /usr/local/
+
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Load assets
+WORKDIR $ROOTDIR/
+
+# Install basic dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && \
+    apt-get update -y && apt-get install --no-install-recommends -y \
+    build-essential \
+    libgdal-dev \
+    libhdf5-dev \
+    cmake
+
+ARG KEALIB_VER=1.4.14
+ARG PACKAGE_DIR=/usr/local/packages
+ARG KEALIB_PACKAGE_DIR=$PACKAGE_DIR/libkea_$KEALIB_VER-1
+ARG make_threads=7
+
+RUN mkdir /usr/local/src/kealib
+COPY . /usr/local/src/kealib
+
+RUN mkdir -p $KEALIB_PACKAGE_DIR/DEBIAN && mkdir -p $KEALIB_PACKAGE_DIR/etc/profile.d
+
+# Install kealib
+RUN cd /usr/local/src/kealib && \
+    cmake \
+    -D CMAKE_VERBOSE_MAKEFILE=ON \
+    -D HDF5_INCLUDE_DIR=/usr/include/hdf5/serial \
+    -D GDAL_INCLUDE_DIR=/usr/include/gdal \
+    -D LIBKEA_WITH_GDAL=ON \
+    -D BUILD_SHARED_LIBS=ON \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    . && \
+    make -j "${make_threads}" && \
+    make install DESTDIR=$KEALIB_PACKAGE_DIR && \
+    echo export GDAL_DRIVER_PATH=/usr/lib/gdalplugins >> $KEALIB_PACKAGE_DIR/etc/profile.d/kealib.sh
+   
+COPY ./contrib/ubuntu/focal_ubuntugis_stable/DEBIAN $KEALIB_PACKAGE_DIR/DEBIAN
+RUN dpkg-deb --build $KEALIB_PACKAGE_DIR
+RUN echo "The package is built and is available in the image in $PACKAGE_DIR"

--- a/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
+++ b/contrib/ubuntu/focal_ubuntugis_unstable/Dockerfile
@@ -54,6 +54,6 @@ RUN cd /usr/local/src/kealib && \
     make install DESTDIR=$KEALIB_PACKAGE_DIR && \
     echo export GDAL_DRIVER_PATH=/usr/lib/gdalplugins >> $KEALIB_PACKAGE_DIR/etc/profile.d/kealib.sh
    
-COPY ./contrib/ubuntu/focal_ubuntugis_stable/DEBIAN $KEALIB_PACKAGE_DIR/DEBIAN
+COPY ./contrib/ubuntu/focal_ubuntugis_unstable/DEBIAN $KEALIB_PACKAGE_DIR/DEBIAN
 RUN dpkg-deb --build $KEALIB_PACKAGE_DIR
 RUN echo "The package is built and is available in the image in $PACKAGE_DIR"


### PR DESCRIPTION
Added some docker files to streamline the building of ubuntu .deb packages compatible with ubuntu 20.04 with the ubuntugis PPA (stable and unstable)

This was done for our own convenience in packaging rsgislib for install - if you think it could be used more widely, then please merge this in.