### PR TITLE
Add PKGBUILD to build on arch

### DIFF
--- a/contrib/arch/PKGBUILD
+++ b/contrib/arch/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Maximilian Friedersdorff <maximilian.friedersdorff@envsys.co.uk>
+pkgname=libkea
+pkgver=1.4.14
+pkgrel=1
+epoch=
+pkgdesc="Library for interfacing with the KEA file format, a HDF5 based Raster File Format"
+arch=("x86_64")
+url="http://kealib.org"
+license=('MIT')
+groups=()
+depends=('hdf5')
+source=("https://github.com/ubarsc/kealib/archive/refs/tags/kealib-1.4.14.tar.gz")
+sha256sums=("b3f73104acebe5304ecce5c19c1560def66fd5c448ce251e9486494baeb141bc")
+
+prepare() {
+    mv "kealib-kealib-$pkgver" "$pkgname-$pkgver"
+
+}
+build() {
+        cd "$pkgname-$pkgver"
+        cmake \
+            -D CMAKE_VERBOSE_MAKEFILE=ON \
+            -D HDF5_INCLUDE_DIR=/usr/include/hdf5/serial \
+            -D GDAL_INCLUDE_DIR=/usr/include/gdal \
+            -D LIBKEA_WITH_GDAL=ON \
+            -D BUILD_SHARED_LIBS=ON \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_INSTALL_PREFIX=/usr \
+            .
+        make
+}
+
+package() {
+        cd "$pkgname-$pkgver"
+        make DESTDIR="$pkgdir/" install
+        mkdir -p "$pkgdir/etc/profile.d"
+        echo export GDAL_DRIVER_PATH=/usr/lib/gdalplugins >> "$pkgdir/etc/profile.d/kealib.sh"
+}


### PR DESCRIPTION
To build and package kealib on arch linux.

Ideally this would be in the [Arch User Repository](https://aur.archlinux.org/) instead of or in addition to this repo.  Just as soon as I've figured out how to do that, I'll do that!