### PR TITLE
add support for 64 bit images for GDAL versions that support it

### DIFF
--- a/gdal/keaband.h
+++ b/gdal/keaband.h
@@ -40,6 +40,13 @@
     #pragma message ("HAVE_RFC40 not present")
 #endif
 
+#if (GDAL_VERSION_MAJOR > 3) || ((GDAL_VERSION_MAJOR == 3) && (GDAL_VERSION_MINOR >= 5))
+    #define HAVE_64BITIMAGES
+    #pragma message ("defining HAVE_64BITIMAGES")
+#else
+    #pragma message ("HAVE_64BITIMAGES not present")
+#endif
+
 class KEAOverview;
 class KEAMaskBand;
 

--- a/gdal/keadataset.cpp
+++ b/gdal/keadataset.cpp
@@ -49,12 +49,22 @@ GDALDataType KEA_to_GDAL_Type( kealib::KEADataType ekeaType )
         case kealib::kea_32int:
             egdalType = GDT_Int32;
             break;
+#ifdef HAVE_64BITIMAGES
+        case kealib::kea_64int:
+            egdalType = GDT_Int64;
+            break;
+#endif
         case kealib::kea_16uint:
             egdalType = GDT_UInt16;
             break;
         case kealib::kea_32uint:
             egdalType = GDT_UInt32;
             break;
+#ifdef HAVE_64BITIMAGES
+        case kealib::kea_64uint:
+            egdalType = GDT_UInt64;
+            break;
+#endif
         case kealib::kea_32float:
             egdalType = GDT_Float32;
             break;
@@ -83,12 +93,22 @@ kealib::KEADataType GDAL_to_KEA_Type( GDALDataType egdalType )
         case GDT_Int32:
             ekeaType = kealib::kea_32int;
             break;
+#ifdef HAVE_64BITIMAGES
+        case GDT_Int64:
+            ekeaType = kealib::kea_64int;
+            break;
+#endif
         case GDT_UInt16:
             ekeaType = kealib::kea_16uint;
             break;
         case GDT_UInt32:
             ekeaType = kealib::kea_32uint;
             break;
+#ifdef HAVE_64BITIMAGES
+        case GDT_UInt64:
+            ekeaType = kealib::kea_64uint;
+            break;
+#endif
         case GDT_Float32:
             ekeaType = kealib::kea_32float;
             break;


### PR DESCRIPTION
See https://github.com/OSGeo/gdal/pull/5710

This updates the out-of-tree GDAL plugin.

I've tried not to break older versions of GDAL... 