### PR TITLE
fix kea-config.bat for Windows cmake builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,9 +52,6 @@ set_target_properties(${LIBKEA_LIB_NAME}
     SOVERSION ${LIBKEA_VERSION_MAJOR}.${LIBKEA_VERSION_MINOR}
     VERSION ${LIBKEA_VERSION}
 )
-if(MSVC AND NOT BUILD_SHARED_LIBS)
-  set_target_properties(${LIBKEA_LIB_NAME} PROPERTIES OUTPUT_NAME "libkea")
-endif()
 
 add_library(Kealib INTERFACE)
 target_link_libraries(Kealib INTERFACE "${LIBKEA_LIB_NAME}")

--- a/tools/kea-config.bat.in
+++ b/tools/kea-config.bat.in
@@ -15,7 +15,7 @@ IF "%1"=="" (
 	    IF "%1"=="--prefix" echo @CMAKE_INSTALL_PREFIX@
 	    IF "%1"=="--version" echo @LIBKEA_VERSION@
 	    IF "%1"=="--cflags" echo -I@CMAKE_INSTALL_PREFIX@/@PROJECT_HEADER_DIR@
-	    IF "%1"=="--libs" echo -LIBPATH:@CMAKE_INSTALL_PREFIX@/@PROJECT_LIBRARY_DIR@ @LIBKEA_LIB_NAME@.lib 
+	    IF "%1"=="--libs" echo -LIBPATH:@CMAKE_INSTALL_PREFIX@/@PROJECT_LIBRARY_DIR@ lib@LIBKEA_LIB_NAME@.lib 
 	    IF "%1"=="--includes" echo @CMAKE_INSTALL_PREFIX@/@PROJECT_HEADER_DIR@
 		shift
 		goto :printValue


### PR DESCRIPTION
Fixes #18 

The library name is always `libkea.lib` on Windows due to https://github.com/ubarsc/kealib/blob/master/src/CMakeLists.txt#L50 although this is probably non-standard in the Windows world. Fixing so that the `kea-config.bat` is correct.

Also tidied up a section of cmake code that is redundant and confusing (created a `liblibkea.lib` for static builds).