### PR TITLE
change way awkward version detection works

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,12 +24,15 @@ project(extrat LANGUAGES CXX)
 # No GDAL since we only depend on it at run time
 find_package(Python 3.7 COMPONENTS Interpreter Development)
 
-# Find version of awkward we have installed
-message(STATUS "Finding awkward version via Python")
-# don't import all of awkward - has some C libraries that won't work for cross compilation
-EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "from awkward._version import __version__;print(__version__)" OUTPUT_VARIABLE AWKWARD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(AWKWARD_VERSION "" CACHE STRING "Set version of awkward being used. Determined via Python if not set")
 if(AWKWARD_VERSION STREQUAL "")
-    message(FATAL_ERROR "Unable to import awkward")
+    # Find version of awkward we have installed
+    message(STATUS "Finding awkward version via Python")
+    # don't import all of awkward - has some C libraries that won't work for cross compilation
+    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "import awkward; print(awkward.__version__)" OUTPUT_VARIABLE AWKWARD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(AWKWARD_VERSION STREQUAL "")
+        message(FATAL_ERROR "Unable to import awkward")
+    endif()
 endif()
 message(STATUS "Using awkward version ${AWKWARD_VERSION}")
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -25,7 +25,12 @@ project(extrat LANGUAGES CXX)
 find_package(Python 3.7 COMPONENTS Interpreter Development)
 
 # Find version of awkward we have installed
-EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "import awkward; print(awkward.__version__)" OUTPUT_VARIABLE AWKWARD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Finding awkward version via Python")
+# don't import all of awkward - has some C libraries that won't work for cross compilation
+EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -c "from awkward._version import __version__;print(__version__)" OUTPUT_VARIABLE AWKWARD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(AWKWARD_VERSION STREQUAL "")
+    message(FATAL_ERROR "Unable to import awkward")
+endif()
 message(STATUS "Using awkward version ${AWKWARD_VERSION}")
 
 # get awkward headers

--- a/python/build_neighbours.py
+++ b/python/build_neighbours.py
@@ -82,6 +82,9 @@ def main():
     # we need the dataset for NeighbourAccumulator
     # Open using GDAL here, test routines can supply a fake
     # GDAL dataset.
+    # only import here so we don't need GDAL for testing
+    from osgeo import gdal
+    gdal.UseExceptions()
     ds = gdal.Open(cmdargs.infile, gdal.GA_Update)
     
     buildNeighbours(ds, cmdargs.band, cmdargs.tilesize, cmdargs.eightway)

--- a/python/extrat.cpp
+++ b/python/extrat.cpp
@@ -775,6 +775,13 @@ pybind11::object getImageBlock(pybind11::object &dataset, uint32_t nBand,
             pImageIO->readImageBlock2Band(nBand, buf.ptr, col, row, xsize, ysize, xsize, ysize, dtype);
             return result;
         }
+        else if( dtype == kealib::kea_16uint)
+        {
+            auto result = pybind11::array_t<uint16_t>({ysize, xsize});
+            pybind11::buffer_info buf = result.request();
+            pImageIO->readImageBlock2Band(nBand, buf.ptr, col, row, xsize, ysize, xsize, ysize, dtype);
+            return result;
+        }
         else if( dtype == kealib::kea_32int)
         {
             auto result = pybind11::array_t<int32_t>({ysize, xsize});


### PR DESCRIPTION
Importing the whole of awkward loads some C libs and this doesn't work during cross compilation. Workaround is to only load the module that only has the version in it. 
Also add detection for the awkward import failing.