### PR TITLE
Fix Kealib interface target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ source_group("include_kea" FILES ${LIBKEA_H})
 ###############################################################################
 # Build, link and install library
 add_library(${LIBKEA_LIB_NAME} ${LIBKEA_CPP} ${LIBKEA_H} )
-target_link_libraries(${LIBKEA_LIB_NAME} ${HDF5_LIBRARIES})
+target_link_libraries(${LIBKEA_LIB_NAME} PRIVATE ${HDF5_LIBRARIES})
 
 include(GenerateExportHeader)
 generate_export_header(${LIBKEA_LIB_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,6 @@ set_target_properties(${LIBKEA_LIB_NAME}
 )
 
 add_library(Kealib INTERFACE)
-target_include_directories(Kealib INTERFACE $<INSTALL_INTERFACE:include>)
 target_link_libraries(Kealib INTERFACE ${LIBKEA_LIB_NAME})
 ###############################################################################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,21 +54,8 @@ set_target_properties(${LIBKEA_LIB_NAME}
 )
 
 add_library(Kealib INTERFACE)
-target_include_directories(Kealib INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-# TODO: a better way??
-if(MSVC)
-    target_link_libraries(Kealib INTERFACE 
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libkea${CMAKE_IMPORT_LIBRARY_SUFFIX}>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/lib/libkea${CMAKE_IMPORT_LIBRARY_SUFFIX}>)
-else()
-    target_link_libraries(Kealib INTERFACE 
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/libkea${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/lib/libkea${CMAKE_SHARED_LIBRARY_SUFFIX}>)
-endif(MSVC)
+target_include_directories(Kealib INTERFACE $<INSTALL_INTERFACE:include>)
+target_link_libraries(Kealib INTERFACE ${LIBKEA_LIB_NAME})
 ###############################################################################
 
 ###############################################################################

--- a/src/Config.cmake.in
+++ b/src/Config.cmake.in
@@ -1,5 +1,14 @@
 @PACKAGE_INIT@
 
+if(NOT "@BUILD_SHARED_LIBS@")
+    # FindHDF5.cmake may expose exported targets in HDF5_LIBRARIES.
+    include(CMakeFindDependencyMacro)
+    if(NOT DEFINED HDF5_USE_STATIC_LIBRARIES)
+        set(HDF5_USE_STATIC_LIBRARIES "@HDF5_USE_STATIC_LIBRARIES@")
+    endif()
+    find_dependency(HDF5)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/libkeaTargets.cmake")
 
 check_required_components(libkea)


### PR DESCRIPTION
This PR fixes using libkea::Kealib with static library linkage. This change comes from trying to add kealib support to the vcpkg port of GDAL: https://github.com/microsoft/vcpkg/pull/35437

If I understand the intention correctly, `Kealib` is just a constant interface name for the variable actual library target name. However, ATM it is hard-coded to use the shared link library which isn't created in static builds, and there is a TODO comment attached to this CMake code. This PR suggests to simply let CMake take care of forwarding transitive usage requirements from Kealib's interface link libraries by refering to the actual library as a cmake target.

It wouldn't be necessary to add any interface include directories for pure CMake target usage. But I left the installed interface include directory in case some consumer wants to read the property.

