### PR TITLE
Export `Kealib` CMake package with `Kealib::Kealib`

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,12 +51,12 @@ if(NOT awkward_POPULATED)
 endif()
 
 find_package(pybind11 CONFIG REQUIRED)
-find_package(libkea CONFIG REQUIRED)
+find_package(Kealib CONFIG REQUIRED)
 
 pybind11_add_module(extrat extrat.cpp)
 target_include_directories(extrat BEFORE PRIVATE "${KEALIB_INCLUDE}")
 set_target_properties(extrat PROPERTIES CXX_VISIBILITY_PRESET hidden)
-target_link_libraries(extrat PRIVATE libkea::Kealib awkward::layout-builder)
+target_link_libraries(extrat PRIVATE Kealib::Kealib awkward::layout-builder)
 
 install(FILES kea_build_neighbours DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 set(PYKEA_INSTALL_DIR "${Python_SITELIB}/kealib" CACHE PATH "Install Dir for Python Bindings")
@@ -67,10 +67,15 @@ install(FILES __init__.py build_neighbours.py DESTINATION ${PYKEA_INSTALL_DIR})
 Python_add_library(fakegdal MODULE WITH_SOABI fakegdal.cpp)
 get_target_property(FAKEGDAL_SUFFIX fakegdal SUFFIX)
 set(FAKEGDAL_NAME "fakegdal${FAKEGDAL_SUFFIX}")
-target_link_libraries(fakegdal PRIVATE libkea::Kealib)
+target_link_libraries(fakegdal PRIVATE Kealib::Kealib)
 
 add_executable(testseg testseg.cpp)
 target_link_libraries(testseg PRIVATE libkea::Kealib)
+
+# Remove in release 1.6.0
+find_package(libkea CONFIG REQUIRED)
+add_executable(testseg_libkea testseg.cpp)
+target_link_libraries(testseg_libkea PRIVATE libkea::Kealib)
 
 # custom install step to create .pyc files
 install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${PYKEA_INSTALL_DIR})")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,9 +68,20 @@ target_link_libraries (test1 ${LIBKEA_LIB_NAME})
 # Package
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/KealibConfig.cmake"
+  INSTALL_DESTINATION lib/cmake/Kealib
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/KealibConfigVersion.cmake"
+  VERSION "${LIBKEA_VERSION}"
+  COMPATIBILITY AnyNewerVersion
+)
+# Remove in release 1.6.0
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/libkeaConfig.cmake"
   INSTALL_DESTINATION lib/cmake/libkea
 )
+# Remove in release 1.6.0
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/libkeaConfigVersion.cmake"
   VERSION "${LIBKEA_VERSION}"
@@ -87,8 +98,18 @@ install(FILES ${LIBKEA_H} ${CMAKE_CURRENT_BINARY_DIR}/include/libkea/kea_export.
         DESTINATION include/libkea)
 install(EXPORT libkeaTargets
         FILE libkeaTargets.cmake
+        NAMESPACE Kealib::
+        DESTINATION lib/cmake/Kealib)
+install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/KealibConfig.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/KealibConfigVersion.cmake"
+        DESTINATION lib/cmake/Kealib)
+# Remove in release 1.6.0
+install(EXPORT libkeaTargets
+        FILE libkeaTargets.cmake
         NAMESPACE libkea::
         DESTINATION lib/cmake/libkea)
+# Remove in release 1.6.0
 install(FILES
           "${CMAKE_CURRENT_BINARY_DIR}/libkeaConfig.cmake"
           "${CMAKE_CURRENT_BINARY_DIR}/libkeaConfigVersion.cmake"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set_target_properties(${LIBKEA_LIB_NAME}
 
 add_library(Kealib INTERFACE)
 target_link_libraries(Kealib INTERFACE ${LIBKEA_LIB_NAME})
+add_library(Kealib::Kealib ALIAS ${LIBKEA_LIB_NAME})
 ###############################################################################
 
 ###############################################################################


### PR DESCRIPTION
For https://github.com/ubarsc/kealib/pull/31#issuecomment-1840101026:

Enable the following usage pattern:
~~~cmake
find_package(Kealib CONFIG REQUIRED)
target_link_libraries(main PRIVATE Kealib::Kealib)
~~~

- Independent of Kealib library linkage.
- Package name consist with project name.
- Target name and namespace consistent with package name.

Enable the following usage pattern (untested):
~~~cmake
add_subdirectory(my-kealib-subdir)
target_link_libraries(main PRIVATE Kealib::Kealib)
~~~
