### PR TITLE
Add C++11 as build requirement in CMake

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Dependencies
       shell: bash -el {0}
       run: |
-        conda install cmake awkward hdf5 python numpy libgdal pybind11
+        conda install cmake awkward awkward-cpp hdf5 python numpy libgdal pybind11
     - name: Cmake
       shell: bash -el {0}
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Dependencies
       shell: bash -el {0}
       run: |
-        conda install cmake awkward awkward-cpp hdf5 python numpy libgdal pybind11
+        conda install cmake awkward>=2.5.0 hdf5 python numpy libgdal pybind11
     - name: Cmake
       shell: bash -el {0}
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Dependencies
       shell: bash -el {0}
       run: |
-        conda install cmake awkward>=2.5.0 hdf5 python numpy libgdal pybind11
+        conda install cmake "awkward>=2.5.0" hdf5 python numpy libgdal pybind11
     - name: Cmake
       shell: bash -el {0}
       run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ source_group("include_kea" FILES ${LIBKEA_H})
 # Build, link and install library
 add_library(${LIBKEA_LIB_NAME} ${LIBKEA_CPP} ${LIBKEA_H} )
 target_link_libraries(${LIBKEA_LIB_NAME} PRIVATE ${HDF5_LIBRARIES})
+target_compile_features(${LIBKEA_LIB_NAME} PUBLIC cxx_std_11)
 
 include(GenerateExportHeader)
 generate_export_header(${LIBKEA_LIB_NAME}


### PR DESCRIPTION
The Kealib uses C++11 for instance:

- https://github.com/ubarsc/kealib/blob/659d893126447786981e4ff7013556e474b13525/src/libkea/KEAAttributeTable.cpp#L186
- https://github.com/ubarsc/kealib/blob/659d893126447786981e4ff7013556e474b13525/src/libkea/KEAImageIO.cpp#L3102


However, the CMakeLists.txt does not configures, which breaks in older compiler that does not C++11 or higher as defaulted standard version, like GCC 5:

```
cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="build/Release/generators/toolchain.cmake" -DCMAKE_INSTALL_PREFIX="package" -DHDF5_USE_STATIC_LIBRARIES="ON" -DHDF5_PREFER_PARALLEL="OFF" -DHDF5_THREADSAFE="OFF" -DLIBKEA_WITH_GDAL="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" ${PWD}
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
...
-- Generating done

cmake --build build/Release -- -j12
Scanning dependencies of target kea
[ 14%] Building CXX object src/CMakeFiles/kea.dir/libkea/KEAImageIO.cpp.o
[ 28%] Building CXX object src/CMakeFiles/kea.dir/libkea/KEAAttributeTableInMem.cpp.o
[ 42%] Building CXX object src/CMakeFiles/kea.dir/libkea/KEAAttributeTable.cpp.o
[ 57%] Building CXX object src/CMakeFiles/kea.dir/libkea/KEAAttributeTableFile.cpp.o
In file included from /usr/include/c++/5/cinttypes:35:0,
                 from /home/foobar/kealib/src/libkea/KEAAttributeTable.cpp:31:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
```

This PR adds explicit requirement for C++11 in the CMakeLists.txt.
