### PR TITLE
Add thread safety and quieten hdf5 stack trace

### DIFF
--- a/include/libkea/KEAAttributeTable.h
+++ b/include/libkea/KEAAttributeTable.h
@@ -98,10 +98,10 @@ namespace kealib{
         void   *p;
     } VarLenFieldHDF;
     
-    class KEA_EXPORT KEAAttributeTable
+    class KEA_EXPORT KEAAttributeTable : public KEABase
     {
     public:
-        KEAAttributeTable(KEAATTType keaAttType);
+        KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<std::recursive_mutex>& mutex);
         virtual KEAATTType getKEAATTType() const;
         
         virtual bool getBoolField(size_t fid, const std::string &name) const=0;

--- a/include/libkea/KEAAttributeTable.h
+++ b/include/libkea/KEAAttributeTable.h
@@ -101,7 +101,7 @@ namespace kealib{
     class KEA_EXPORT KEAAttributeTable : public KEABase
     {
     public:
-        KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<std::recursive_mutex>& mutex);
+        KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<kealib::kea_mutex>& mutex);
         virtual KEAATTType getKEAATTType() const;
         
         virtual bool getBoolField(size_t fid, const std::string &name) const=0;

--- a/include/libkea/KEAAttributeTableFile.h
+++ b/include/libkea/KEAAttributeTableFile.h
@@ -46,7 +46,7 @@ namespace kealib{
     class KEA_EXPORT KEAAttributeTableFile : public KEAAttributeTable
     {
     public:
-        KEAAttributeTableFile(H5::H5File *keaImgIn, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn=KEA_DEFLATE);
+        KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<std::recursive_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn=KEA_DEFLATE);
         
         bool getBoolField(size_t fid, const std::string &name) const;
         int64_t getIntField(size_t fid, const std::string &name) const;
@@ -91,7 +91,7 @@ namespace kealib{
         
         void addRows(size_t numRows);
         
-        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
+        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         void exportToKeaFile(H5::H5File *keaImg, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         
         ~KEAAttributeTableFile();

--- a/include/libkea/KEAAttributeTableFile.h
+++ b/include/libkea/KEAAttributeTableFile.h
@@ -46,7 +46,7 @@ namespace kealib{
     class KEA_EXPORT KEAAttributeTableFile : public KEAAttributeTable
     {
     public:
-        KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<std::recursive_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn=KEA_DEFLATE);
+        KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<kealib::kea_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn=KEA_DEFLATE);
         
         bool getBoolField(size_t fid, const std::string &name) const;
         int64_t getIntField(size_t fid, const std::string &name) const;
@@ -91,7 +91,7 @@ namespace kealib{
         
         void addRows(size_t numRows);
         
-        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
+        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<kealib::kea_mutex>& mutex, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         void exportToKeaFile(H5::H5File *keaImg, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         
         ~KEAAttributeTableFile();

--- a/include/libkea/KEAAttributeTableInMem.h
+++ b/include/libkea/KEAAttributeTableInMem.h
@@ -46,7 +46,7 @@ namespace kealib{
     class KEA_EXPORT KEAAttributeTableInMem : public KEAAttributeTable
     {
     public:
-        KEAAttributeTableInMem(const std::shared_ptr<std::recursive_mutex>& mutex);
+        KEAAttributeTableInMem(const std::shared_ptr<kealib::kea_mutex>& mutex);
         
         bool getBoolField(size_t fid, const std::string &name) const;
         int64_t getIntField(size_t fid, const std::string &name) const;
@@ -93,7 +93,7 @@ namespace kealib{
         
         void exportToKeaFile(H5::H5File *keaImg, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         
-        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band);
+        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<kealib::kea_mutex>& mutex, unsigned int band);
         
         ~KEAAttributeTableInMem();
     protected:

--- a/include/libkea/KEAAttributeTableInMem.h
+++ b/include/libkea/KEAAttributeTableInMem.h
@@ -46,7 +46,7 @@ namespace kealib{
     class KEA_EXPORT KEAAttributeTableInMem : public KEAAttributeTable
     {
     public:
-        KEAAttributeTableInMem();
+        KEAAttributeTableInMem(const std::shared_ptr<std::recursive_mutex>& mutex);
         
         bool getBoolField(size_t fid, const std::string &name) const;
         int64_t getIntField(size_t fid, const std::string &name) const;
@@ -93,7 +93,7 @@ namespace kealib{
         
         void exportToKeaFile(H5::H5File *keaImg, unsigned int band, unsigned int chunkSize=KEA_ATT_CHUNK_SIZE, unsigned int deflate=KEA_DEFLATE);
         
-        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, unsigned int band);
+        static KEAAttributeTable* createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band);
         
         ~KEAAttributeTableInMem();
     protected:

--- a/include/libkea/KEACommon.h
+++ b/include/libkea/KEACommon.h
@@ -327,7 +327,12 @@ namespace kealib{
         H5E_auto2_t m_func;
         void *m_clientData;  
     };
+
+    typedef std::recursive_mutex kea_mutex;
+    typedef std::lock_guard<kea_mutex> kea_lock;
     
+    // base class for KEA classes. Either create a 
+    // mutex themselves, or share one from the KEAImageIO class 
     class KEA_EXPORT KEABase
     {
     public:
@@ -335,16 +340,16 @@ namespace kealib{
         {
             // default constructor
             // create a new mutex
-            m_mutex = std::make_shared<std::recursive_mutex>();
+            m_mutex = std::make_shared<kea_mutex>();
         }
-        KEABase(const std::shared_ptr<std::recursive_mutex>& other)
+        KEABase(const std::shared_ptr<kea_mutex>& other)
         {
             // use this other when you want to use another mutex
             // to lock access
             m_mutex = other;          
         }
     protected:
-        std::shared_ptr<std::recursive_mutex>  m_mutex;
+        std::shared_ptr<kea_mutex>  m_mutex;
     };
     
 }

--- a/include/libkea/KEAImageIO.h
+++ b/include/libkea/KEAImageIO.h
@@ -45,7 +45,7 @@
 
 namespace kealib{
         
-    class KEA_EXPORT KEAImageIO
+    class KEA_EXPORT KEAImageIO : public KEABase
     {
     public:
         KEAImageIO();

--- a/src/libkea/KEAAttributeTable.cpp
+++ b/src/libkea/KEAAttributeTable.cpp
@@ -32,7 +32,8 @@
 
 namespace kealib{
     
-    KEAAttributeTable::KEAAttributeTable(KEAATTType keaAttType)
+    KEAAttributeTable::KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<std::recursive_mutex>& mutex)
+        : KEABase(mutex)
     {
         attType = keaAttType;
         numBoolFields = 0;

--- a/src/libkea/KEAAttributeTable.cpp
+++ b/src/libkea/KEAAttributeTable.cpp
@@ -32,7 +32,7 @@
 
 namespace kealib{
     
-    KEAAttributeTable::KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<std::recursive_mutex>& mutex)
+    KEAAttributeTable::KEAAttributeTable(KEAATTType keaAttType, const std::shared_ptr<kealib::kea_mutex>& mutex)
         : KEABase(mutex)
     {
         attType = keaAttType;

--- a/src/libkea/KEAAttributeTableFile.cpp
+++ b/src/libkea/KEAAttributeTableFile.cpp
@@ -45,7 +45,7 @@ namespace kealib{
         free(ptr);
     }
 
-    KEAAttributeTableFile::KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<std::recursive_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn) : KEAAttributeTable(kea_att_file, mutex)
+    KEAAttributeTableFile::KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<kealib::kea_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn) : KEAAttributeTable(kea_att_file, mutex)
     {
         numRows = numRowsIn;
         chunkSize = chunkSizeIn;
@@ -320,8 +320,8 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableFile::getBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -419,8 +419,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -511,8 +511,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -603,8 +603,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *psBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -708,8 +708,8 @@ namespace kealib{
     {
         try
         {
-            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-            KEAStackPrintState();
+            kealib::kea_lock lock(*this->m_mutex); 
+            KEAStackPrintState printState;
             if(!neighbours->empty())
             {
                 for(auto iterNeigh = neighbours->begin(); iterNeigh != neighbours->end(); ++iterNeigh)
@@ -862,8 +862,8 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableFile::setBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -962,8 +962,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1054,8 +1054,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1146,8 +1146,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *papszStrList)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1257,8 +1257,8 @@ namespace kealib{
         
         try
         {
-            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-            KEAStackPrintState();
+            kealib::kea_lock lock(*this->m_mutex); 
+            KEAStackPrintState printState;
             H5::DataSet *neighboursDataset = nullptr;
             try
             {
@@ -1383,8 +1383,8 @@ namespace kealib{
     {
         try
         {
-            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-            KEAStackPrintState();
+            kealib::kea_lock lock(*this->m_mutex); 
+            KEAStackPrintState printState;
             // WRITE THE ATT SIZE USED TO THE FILE.
             hsize_t sizeDataOffset[1];
             sizeDataOffset[0] = 0;
@@ -1431,8 +1431,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttBoolField(KEAATTField field, bool val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields+1, numIntFields, numFloatFields, numStringFields);
         
@@ -1569,8 +1569,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttIntField(KEAATTField field, int64_t val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields+1, numFloatFields, numStringFields);
         
@@ -1706,8 +1706,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttFloatField(KEAATTField field, float val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields, numFloatFields+1, numStringFields);
         
@@ -1843,8 +1843,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttStringField(KEAATTField field, const std::string &val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields, numFloatFields, numStringFields+1);
         
@@ -1987,8 +1987,8 @@ namespace kealib{
     {
         if( numRowsIn > 0 )
         {
-            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-            KEAStackPrintState();
+            kealib::kea_lock lock(*this->m_mutex); 
+            KEAStackPrintState printState;
             // update header
             numRows += numRowsIn;
             updateSizeHeader(numBoolFields, numIntFields, numFloatFields, numStringFields);
@@ -2050,7 +2050,7 @@ namespace kealib{
         }
     }
     
-    KEAAttributeTable* KEAAttributeTableFile::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band, unsigned int chunkSizeIn, unsigned int deflate)
+    KEAAttributeTable* KEAAttributeTableFile::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<kealib::kea_mutex>& mutex, unsigned int band, unsigned int chunkSizeIn, unsigned int deflate)
     {
         // Create instance of class to populate and return.
         std::string bandPathBase = KEA_DATASETNAME_BAND + uint2Str(band);

--- a/src/libkea/KEAAttributeTableFile.cpp
+++ b/src/libkea/KEAAttributeTableFile.cpp
@@ -45,7 +45,7 @@ namespace kealib{
         free(ptr);
     }
 
-    KEAAttributeTableFile::KEAAttributeTableFile(H5::H5File *keaImgIn, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn) : KEAAttributeTable(kea_att_file)
+    KEAAttributeTableFile::KEAAttributeTableFile(H5::H5File *keaImgIn, const std::shared_ptr<std::recursive_mutex>& mutex, const std::string &bandPathBaseIn, size_t numRowsIn, size_t chunkSizeIn, unsigned int deflateIn) : KEAAttributeTable(kea_att_file, mutex)
     {
         numRows = numRowsIn;
         chunkSize = chunkSizeIn;
@@ -320,6 +320,8 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableFile::getBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -417,6 +419,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -507,6 +511,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -597,6 +603,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::getStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *psBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -700,6 +708,8 @@ namespace kealib{
     {
         try
         {
+            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+            KEAStackPrintState();
             if(!neighbours->empty())
             {
                 for(auto iterNeigh = neighbours->begin(); iterNeigh != neighbours->end(); ++iterNeigh)
@@ -852,6 +862,8 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableFile::setBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -950,6 +962,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1040,6 +1054,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1130,6 +1146,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::setStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *papszStrList)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if((startfid+len) > numRows)
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -1239,6 +1257,8 @@ namespace kealib{
         
         try
         {
+            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+            KEAStackPrintState();
             H5::DataSet *neighboursDataset = nullptr;
             try
             {
@@ -1363,6 +1383,8 @@ namespace kealib{
     {
         try
         {
+            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+            KEAStackPrintState();
             // WRITE THE ATT SIZE USED TO THE FILE.
             hsize_t sizeDataOffset[1];
             sizeDataOffset[0] = 0;
@@ -1409,6 +1431,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttBoolField(KEAATTField field, bool val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields+1, numIntFields, numFloatFields, numStringFields);
         
@@ -1545,6 +1569,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttIntField(KEAATTField field, int64_t val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields+1, numFloatFields, numStringFields);
         
@@ -1680,6 +1706,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttFloatField(KEAATTField field, float val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields, numFloatFields+1, numStringFields);
         
@@ -1815,6 +1843,8 @@ namespace kealib{
     
     void KEAAttributeTableFile::addAttStringField(KEAATTField field, const std::string &val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         // field already been inserted into this->fields by base class
         updateSizeHeader(numBoolFields, numIntFields, numFloatFields, numStringFields+1);
         
@@ -1957,6 +1987,8 @@ namespace kealib{
     {
         if( numRowsIn > 0 )
         {
+            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+            KEAStackPrintState();
             // update header
             numRows += numRowsIn;
             updateSizeHeader(numBoolFields, numIntFields, numFloatFields, numStringFields);
@@ -2018,11 +2050,12 @@ namespace kealib{
         }
     }
     
-    KEAAttributeTable* KEAAttributeTableFile::createKeaAtt(H5::H5File *keaImg, unsigned int band, unsigned int chunkSizeIn, unsigned int deflate)
+    KEAAttributeTable* KEAAttributeTableFile::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band, unsigned int chunkSizeIn, unsigned int deflate)
     {
         // Create instance of class to populate and return.
         std::string bandPathBase = KEA_DATASETNAME_BAND + uint2Str(band);
         KEAAttributeTableFile *att = nullptr;
+        // no lock needed - should be done by caller
         
         try
         {
@@ -2068,7 +2101,7 @@ namespace kealib{
                 throw KEAIOException("The attribute table size field is not present.");
             }
             
-            att = new KEAAttributeTableFile(keaImg, bandPathBase, numRows, chunkSize, deflate);
+            att = new KEAAttributeTableFile(keaImg, mutex, bandPathBase, numRows, chunkSize, deflate);
             
             // READ TABLE HEADERS
             H5::CompType *fieldCompTypeMem = KEAAttributeTable::createAttibuteIdxCompTypeMem();

--- a/src/libkea/KEAAttributeTableInMem.cpp
+++ b/src/libkea/KEAAttributeTableInMem.cpp
@@ -33,7 +33,7 @@
 
 namespace kealib{
     
-    KEAAttributeTableInMem::KEAAttributeTableInMem(const std::shared_ptr<std::recursive_mutex>& mutex) : KEAAttributeTable(kea_att_mem, mutex)
+    KEAAttributeTableInMem::KEAAttributeTableInMem(const std::shared_ptr<kealib::kea_mutex>& mutex) : KEAAttributeTable(kea_att_mem, mutex)
     {
         attRows = new std::vector<KEAATTFeature*>();
     }
@@ -200,7 +200,7 @@ namespace kealib{
     
     bool KEAAttributeTableInMem::getBoolField(size_t fid, size_t colIdx) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -218,7 +218,7 @@ namespace kealib{
     
     int64_t KEAAttributeTableInMem::getIntField(size_t fid, size_t colIdx) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -236,7 +236,7 @@ namespace kealib{
     
     double KEAAttributeTableInMem::getFloatField(size_t fid, size_t colIdx) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -254,7 +254,7 @@ namespace kealib{
     
     std::string KEAAttributeTableInMem::getStringField(size_t fid, size_t colIdx) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -273,7 +273,7 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableInMem::getBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -294,7 +294,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -315,7 +315,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -336,7 +336,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *psBuffer) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -364,7 +364,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setBoolField(size_t fid, size_t colIdx, bool value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -382,7 +382,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setIntField(size_t fid, size_t colIdx, int64_t value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -400,7 +400,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setFloatField(size_t fid, size_t colIdx, double value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -418,7 +418,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setStringField(size_t fid, size_t colIdx, const std::string &value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -437,7 +437,7 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableInMem::setBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -458,7 +458,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -479,7 +479,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -500,7 +500,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *papszStrList)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -531,7 +531,7 @@ namespace kealib{
     
     KEAATTFeature* KEAAttributeTableInMem::getFeature(size_t fid) const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -543,13 +543,13 @@ namespace kealib{
         
     size_t KEAAttributeTableInMem::getSize() const
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         return attRows->size();
     }
     
     void KEAAttributeTableInMem::addAttBoolField(KEAATTField field, bool val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->boolFields->push_back(val);
@@ -558,7 +558,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttIntField(KEAATTField field, int64_t val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->intFields->push_back(val);
@@ -567,7 +567,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttFloatField(KEAATTField field, float val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->floatFields->push_back(val);
@@ -576,7 +576,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttStringField(KEAATTField field, const std::string &val)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->strFields->push_back(val);
@@ -586,7 +586,7 @@ namespace kealib{
     void KEAAttributeTableInMem::addRows(size_t numRows)
     {        
         KEAATTFeature *feat = nullptr;
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        kealib::kea_lock lock(*this->m_mutex); 
         
         for(size_t i = 0; i < numRows; ++i)
         {
@@ -1953,7 +1953,7 @@ namespace kealib{
         }
     }
     
-    KEAAttributeTable* KEAAttributeTableInMem::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band)
+    KEAAttributeTable* KEAAttributeTableInMem::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<kealib::kea_mutex>& mutex, unsigned int band)
     {
         // Create instance of class to populate and return.
         KEAAttributeTableInMem *att = new KEAAttributeTableInMem(mutex);

--- a/src/libkea/KEAAttributeTableInMem.cpp
+++ b/src/libkea/KEAAttributeTableInMem.cpp
@@ -33,7 +33,7 @@
 
 namespace kealib{
     
-    KEAAttributeTableInMem::KEAAttributeTableInMem() : KEAAttributeTable(kea_att_mem)
+    KEAAttributeTableInMem::KEAAttributeTableInMem(const std::shared_ptr<std::recursive_mutex>& mutex) : KEAAttributeTable(kea_att_mem, mutex)
     {
         attRows = new std::vector<KEAATTFeature*>();
     }
@@ -200,6 +200,7 @@ namespace kealib{
     
     bool KEAAttributeTableInMem::getBoolField(size_t fid, size_t colIdx) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -217,6 +218,7 @@ namespace kealib{
     
     int64_t KEAAttributeTableInMem::getIntField(size_t fid, size_t colIdx) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -234,6 +236,7 @@ namespace kealib{
     
     double KEAAttributeTableInMem::getFloatField(size_t fid, size_t colIdx) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -251,6 +254,7 @@ namespace kealib{
     
     std::string KEAAttributeTableInMem::getStringField(size_t fid, size_t colIdx) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -269,6 +273,7 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableInMem::getBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -289,6 +294,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -309,6 +315,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -329,6 +336,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::getStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *psBuffer) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -356,6 +364,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setBoolField(size_t fid, size_t colIdx, bool value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -373,6 +382,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setIntField(size_t fid, size_t colIdx, int64_t value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -390,6 +400,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setFloatField(size_t fid, size_t colIdx, double value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -407,6 +418,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setStringField(size_t fid, size_t colIdx, const std::string &value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -425,6 +437,7 @@ namespace kealib{
     // RFC40
     void KEAAttributeTableInMem::setBoolFields(size_t startfid, size_t len, size_t colIdx, bool *pbBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -445,6 +458,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setIntFields(size_t startfid, size_t len, size_t colIdx, int64_t *pnBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -465,6 +479,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::setFloatFields(size_t startfid, size_t len, size_t colIdx, double *pfBuffer)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -485,6 +500,7 @@ namespace kealib{
 
     void KEAAttributeTableInMem::setStringFields(size_t startfid, size_t len, size_t colIdx, std::vector<std::string> *papszStrList)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if((startfid+len) > attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(startfid+len) + std::string(") is not within the table.");
@@ -515,6 +531,7 @@ namespace kealib{
     
     KEAATTFeature* KEAAttributeTableInMem::getFeature(size_t fid) const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         if(fid >= attRows->size())
         {
             std::string message = std::string("Requested feature (") + sizet2Str(fid) + std::string(") is not within the table.");
@@ -526,11 +543,13 @@ namespace kealib{
         
     size_t KEAAttributeTableInMem::getSize() const
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         return attRows->size();
     }
     
     void KEAAttributeTableInMem::addAttBoolField(KEAATTField field, bool val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->boolFields->push_back(val);
@@ -539,6 +558,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttIntField(KEAATTField field, int64_t val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->intFields->push_back(val);
@@ -547,6 +567,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttFloatField(KEAATTField field, float val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->floatFields->push_back(val);
@@ -555,6 +576,7 @@ namespace kealib{
     
     void KEAAttributeTableInMem::addAttStringField(KEAATTField field, const std::string &val)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         for(auto iterFeat = attRows->begin(); iterFeat != attRows->end(); ++iterFeat)
         {
             (*iterFeat)->strFields->push_back(val);
@@ -564,6 +586,7 @@ namespace kealib{
     void KEAAttributeTableInMem::addRows(size_t numRows)
     {        
         KEAATTFeature *feat = nullptr;
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
         
         for(size_t i = 0; i < numRows; ++i)
         {
@@ -1930,10 +1953,10 @@ namespace kealib{
         }
     }
     
-    KEAAttributeTable* KEAAttributeTableInMem::createKeaAtt(H5::H5File *keaImg, unsigned int band)
+    KEAAttributeTable* KEAAttributeTableInMem::createKeaAtt(H5::H5File *keaImg, const std::shared_ptr<std::recursive_mutex>& mutex, unsigned int band)
     {
         // Create instance of class to populate and return.
-        KEAAttributeTableInMem *att = new KEAAttributeTableInMem();
+        KEAAttributeTableInMem *att = new KEAAttributeTableInMem(mutex);
         
         std::string bandPathBase = KEA_DATASETNAME_BAND + uint2Str(band);
         try

--- a/src/libkea/KEAImageIO.cpp
+++ b/src/libkea/KEAImageIO.cpp
@@ -72,8 +72,8 @@ namespace kealib{
     {
         try 
         {
-            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-            KEAStackPrintState();
+            kealib::kea_lock lock(*this->m_mutex); 
+            KEAStackPrintState printState;
             
             this->keaImgFile = keaImgH5File;
             this->spatialInfoFile = new KEAImageSpatialInfo();
@@ -213,8 +213,8 @@ namespace kealib{
     
     void KEAImageIO::writeImageBlock2Band(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -350,8 +350,8 @@ namespace kealib{
     
     void KEAImageIO::readImageBlock2Band(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -487,8 +487,8 @@ namespace kealib{
     
     void KEAImageIO::createMask(uint32_t band, uint32_t deflate)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -530,8 +530,8 @@ namespace kealib{
     
     void KEAImageIO::writeImageBlock2BandMask(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -667,8 +667,9 @@ namespace kealib{
     
     void KEAImageIO::readImageBlock2BandMask(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex);
+ 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -802,8 +803,8 @@ namespace kealib{
     
     bool KEAImageIO::maskCreated(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
 
         if(!this->fileOpen)
         {
@@ -851,8 +852,8 @@ namespace kealib{
     
     void KEAImageIO::setImageMetaData(const std::string &name, const std::string &value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -903,8 +904,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageMetaData(const std::string &name)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -938,8 +939,8 @@ namespace kealib{
     
     std::vector<std::string> KEAImageIO::getImageMetaDataNames()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -976,8 +977,8 @@ namespace kealib{
     
     std::vector< std::pair<std::string, std::string> > KEAImageIO::getImageMetaData()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1018,8 +1019,8 @@ namespace kealib{
     
     void KEAImageIO::setImageMetaData(const std::vector< std::pair<std::string, std::string> > &data)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1050,8 +1051,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandMetaData(uint32_t band, const std::string &name, const std::string &value)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1102,8 +1103,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageBandMetaData(uint32_t band, const std::string &name)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1137,8 +1138,8 @@ namespace kealib{
     
     std::vector<std::string> KEAImageIO::getImageBandMetaDataNames(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1176,8 +1177,8 @@ namespace kealib{
     
     std::vector< std::pair<std::string, std::string> > KEAImageIO::getImageBandMetaData(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1219,8 +1220,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandMetaData(uint32_t band, const std::vector< std::pair<std::string, std::string> > &data)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1251,8 +1252,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandDescription(uint32_t band, const std::string &description)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1287,8 +1288,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageBandDescription(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1324,8 +1325,8 @@ namespace kealib{
     
     void KEAImageIO::setNoDataValue(uint32_t band, const void *data, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1389,8 +1390,8 @@ namespace kealib{
     
     void KEAImageIO::getNoDataValue(uint32_t band, void *data, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex);
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1451,8 +1452,8 @@ namespace kealib{
     
     void KEAImageIO::undefineNoDataValue(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1497,8 +1498,8 @@ namespace kealib{
     
     std::vector<KEAImageGCP*>* KEAImageIO::getGCPs()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1604,8 +1605,8 @@ namespace kealib{
     
     void KEAImageIO::setGCPs(std::vector<KEAImageGCP*> *gcps, const std::string &projWKT)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1790,8 +1791,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getGCPCount()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1821,8 +1822,8 @@ namespace kealib{
     
     std::string KEAImageIO::getGCPProjection()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1847,8 +1848,8 @@ namespace kealib{
     
     void KEAImageIO::setGCPProjection(const std::string &projWKT)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1889,8 +1890,8 @@ namespace kealib{
     
     void KEAImageIO::setSpatialInfo(KEAImageSpatialInfo *inSpatialInfo)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1966,8 +1967,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getImageBlockSize(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2032,8 +2033,8 @@ namespace kealib{
 
     uint32_t KEAImageIO::getAttributeTableChunkSize(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2100,8 +2101,8 @@ namespace kealib{
     
     KEADataType KEAImageIO::getImageBandDataType(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2149,8 +2150,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandLayerType(uint32_t band, KEALayerType imgLayerType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2181,8 +2182,8 @@ namespace kealib{
     
     KEALayerType KEAImageIO::getImageBandLayerType(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2221,8 +2222,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandClrInterp(uint32_t band, KEABandClrInterp imgLayerClrInterp)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2258,8 +2259,8 @@ namespace kealib{
     
     KEABandClrInterp KEAImageIO::getImageBandClrInterp(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2299,8 +2300,8 @@ namespace kealib{
     
     void KEAImageIO::createOverview(uint32_t band, uint32_t overview, uint64_t xSize, uint64_t ySize)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2406,8 +2407,8 @@ namespace kealib{
     
     void KEAImageIO::removeOverview(uint32_t band, uint32_t overview)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2439,8 +2440,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getOverviewBlockSize(uint32_t band, uint32_t overview)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2505,8 +2506,8 @@ namespace kealib{
     
     void KEAImageIO::writeToOverview(uint32_t band, uint32_t overview, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2619,8 +2620,8 @@ namespace kealib{
     
     void KEAImageIO::readFromOverview(uint32_t band, uint32_t overview, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2730,8 +2731,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getNumOfOverviews(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2763,8 +2764,8 @@ namespace kealib{
     
     void KEAImageIO::getOverviewSize(uint32_t band, uint32_t overview, uint64_t *xSize, uint64_t *ySize)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2861,8 +2862,8 @@ namespace kealib{
     
     void KEAImageIO::setAttributeTable(KEAAttributeTable* att, uint32_t band, uint32_t chunkSize, uint32_t deflate)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2889,8 +2890,8 @@ namespace kealib{
     
     bool KEAImageIO::attributeTablePresent(uint32_t band)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2942,8 +2943,8 @@ namespace kealib{
     
     void KEAImageIO::close()
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         try 
         {
             delete this->spatialInfoFile;
@@ -2968,7 +2969,7 @@ namespace kealib{
         
     H5::H5File* KEAImageIO::createKEAImage(const std::string &fileName, KEADataType dataType, uint32_t xSize, uint32_t ySize, uint32_t numImgBands, std::vector<std::string> *bandDescrips, KEAImageSpatialInfo * spatialInfo, uint32_t imageBlockSize, uint32_t attBlockSize, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize, uint32_t deflate)
     {
-        KEAStackPrintState();
+        KEAStackPrintState printState;
         
         H5::H5File *keaImgH5File = nullptr;
         
@@ -3145,7 +3146,7 @@ namespace kealib{
     
     H5::H5File* KEAImageIO::openKeaH5RW(const std::string &fileName, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize)
     {
-        KEAStackPrintState();
+        KEAStackPrintState printState;
         
         H5::H5File *keaImgH5File = nullptr;
         try 
@@ -3189,7 +3190,7 @@ namespace kealib{
     
     H5::H5File* KEAImageIO::openKeaH5RDOnly(const std::string &fileName, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize)
     {
-        KEAStackPrintState();
+        KEAStackPrintState printState;
         
         H5::H5File *keaImgH5File = nullptr;
         try 
@@ -3234,7 +3235,7 @@ namespace kealib{
     bool KEAImageIO::isKEAImage(const std::string &fileName)
     {
         bool keaImageFound = false;
-        KEAStackPrintState();
+        KEAStackPrintState printState;
         
         try 
         {
@@ -3309,8 +3310,8 @@ namespace kealib{
 
     void KEAImageIO::addImageBand(const KEADataType dataType, const std::string &bandDescrip, const uint32_t imageBlockSize, const uint32_t attBlockSize, const uint32_t deflate)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -3331,8 +3332,8 @@ namespace kealib{
     
     void KEAImageIO::removeImageBand(const uint32_t bandIndex)
     {
-        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
-        KEAStackPrintState();
+        kealib::kea_lock lock(*this->m_mutex); 
+        KEAStackPrintState printState;
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");

--- a/src/libkea/KEAImageIO.cpp
+++ b/src/libkea/KEAImageIO.cpp
@@ -72,6 +72,9 @@ namespace kealib{
     {
         try 
         {
+            std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+            KEAStackPrintState();
+            
             this->keaImgFile = keaImgH5File;
             this->spatialInfoFile = new KEAImageSpatialInfo();
             
@@ -210,6 +213,8 @@ namespace kealib{
     
     void KEAImageIO::writeImageBlock2Band(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -345,6 +350,8 @@ namespace kealib{
     
     void KEAImageIO::readImageBlock2Band(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -480,6 +487,8 @@ namespace kealib{
     
     void KEAImageIO::createMask(uint32_t band, uint32_t deflate)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -521,6 +530,8 @@ namespace kealib{
     
     void KEAImageIO::writeImageBlock2BandMask(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -656,6 +667,8 @@ namespace kealib{
     
     void KEAImageIO::readImageBlock2BandMask(uint32_t band, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -789,6 +802,9 @@ namespace kealib{
     
     bool KEAImageIO::maskCreated(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
+
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -835,6 +851,8 @@ namespace kealib{
     
     void KEAImageIO::setImageMetaData(const std::string &name, const std::string &value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -885,6 +903,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageMetaData(const std::string &name)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -918,6 +938,8 @@ namespace kealib{
     
     std::vector<std::string> KEAImageIO::getImageMetaDataNames()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -954,6 +976,8 @@ namespace kealib{
     
     std::vector< std::pair<std::string, std::string> > KEAImageIO::getImageMetaData()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -994,6 +1018,8 @@ namespace kealib{
     
     void KEAImageIO::setImageMetaData(const std::vector< std::pair<std::string, std::string> > &data)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1024,6 +1050,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandMetaData(uint32_t band, const std::string &name, const std::string &value)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1074,6 +1102,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageBandMetaData(uint32_t band, const std::string &name)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1107,6 +1137,8 @@ namespace kealib{
     
     std::vector<std::string> KEAImageIO::getImageBandMetaDataNames(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1144,6 +1176,8 @@ namespace kealib{
     
     std::vector< std::pair<std::string, std::string> > KEAImageIO::getImageBandMetaData(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1185,6 +1219,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandMetaData(uint32_t band, const std::vector< std::pair<std::string, std::string> > &data)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1215,6 +1251,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandDescription(uint32_t band, const std::string &description)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1249,6 +1287,8 @@ namespace kealib{
     
     std::string KEAImageIO::getImageBandDescription(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1284,6 +1324,8 @@ namespace kealib{
     
     void KEAImageIO::setNoDataValue(uint32_t band, const void *data, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1347,6 +1389,8 @@ namespace kealib{
     
     void KEAImageIO::getNoDataValue(uint32_t band, void *data, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1407,6 +1451,8 @@ namespace kealib{
     
     void KEAImageIO::undefineNoDataValue(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1451,6 +1497,8 @@ namespace kealib{
     
     std::vector<KEAImageGCP*>* KEAImageIO::getGCPs()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1556,6 +1604,8 @@ namespace kealib{
     
     void KEAImageIO::setGCPs(std::vector<KEAImageGCP*> *gcps, const std::string &projWKT)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1740,6 +1790,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getGCPCount()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1769,6 +1821,8 @@ namespace kealib{
     
     std::string KEAImageIO::getGCPProjection()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1793,6 +1847,8 @@ namespace kealib{
     
     void KEAImageIO::setGCPProjection(const std::string &projWKT)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1833,6 +1889,8 @@ namespace kealib{
     
     void KEAImageIO::setSpatialInfo(KEAImageSpatialInfo *inSpatialInfo)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1908,6 +1966,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getImageBlockSize(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -1972,6 +2032,8 @@ namespace kealib{
 
     uint32_t KEAImageIO::getAttributeTableChunkSize(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2038,6 +2100,8 @@ namespace kealib{
     
     KEADataType KEAImageIO::getImageBandDataType(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2085,6 +2149,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandLayerType(uint32_t band, KEALayerType imgLayerType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2115,6 +2181,8 @@ namespace kealib{
     
     KEALayerType KEAImageIO::getImageBandLayerType(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2153,6 +2221,8 @@ namespace kealib{
     
     void KEAImageIO::setImageBandClrInterp(uint32_t band, KEABandClrInterp imgLayerClrInterp)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2188,6 +2258,8 @@ namespace kealib{
     
     KEABandClrInterp KEAImageIO::getImageBandClrInterp(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2227,6 +2299,8 @@ namespace kealib{
     
     void KEAImageIO::createOverview(uint32_t band, uint32_t overview, uint64_t xSize, uint64_t ySize)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2332,6 +2406,8 @@ namespace kealib{
     
     void KEAImageIO::removeOverview(uint32_t band, uint32_t overview)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2363,6 +2439,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getOverviewBlockSize(uint32_t band, uint32_t overview)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2427,6 +2505,8 @@ namespace kealib{
     
     void KEAImageIO::writeToOverview(uint32_t band, uint32_t overview, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeOut, uint64_t ySizeOut, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2539,6 +2619,8 @@ namespace kealib{
     
     void KEAImageIO::readFromOverview(uint32_t band, uint32_t overview, void *data, uint64_t xPxlOff, uint64_t yPxlOff, uint64_t xSizeIn, uint64_t ySizeIn, uint64_t xSizeBuf, uint64_t ySizeBuf, KEADataType inDataType)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2648,6 +2730,8 @@ namespace kealib{
     
     uint32_t KEAImageIO::getNumOfOverviews(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2679,6 +2763,8 @@ namespace kealib{
     
     void KEAImageIO::getOverviewSize(uint32_t band, uint32_t overview, uint64_t *xSize, uint64_t *ySize)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2746,11 +2832,11 @@ namespace kealib{
         {
             if(type == kea_att_mem)
             {
-                att = kealib::KEAAttributeTableInMem::createKeaAtt(this->keaImgFile, band);
+                att = kealib::KEAAttributeTableInMem::createKeaAtt(this->keaImgFile, this->m_mutex, band);
             }
             else if(type == kea_att_file)
             {
-                att = kealib::KEAAttributeTableFile::createKeaAtt(this->keaImgFile, band);
+                att = kealib::KEAAttributeTableFile::createKeaAtt(this->keaImgFile, this->m_mutex, band);
             }
             else
             {
@@ -2775,6 +2861,8 @@ namespace kealib{
     
     void KEAImageIO::setAttributeTable(KEAAttributeTable* att, uint32_t band, uint32_t chunkSize, uint32_t deflate)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2801,6 +2889,8 @@ namespace kealib{
     
     bool KEAImageIO::attributeTablePresent(uint32_t band)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -2852,6 +2942,8 @@ namespace kealib{
     
     void KEAImageIO::close()
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         try 
         {
             delete this->spatialInfoFile;
@@ -2876,7 +2968,7 @@ namespace kealib{
         
     H5::H5File* KEAImageIO::createKEAImage(const std::string &fileName, KEADataType dataType, uint32_t xSize, uint32_t ySize, uint32_t numImgBands, std::vector<std::string> *bandDescrips, KEAImageSpatialInfo * spatialInfo, uint32_t imageBlockSize, uint32_t attBlockSize, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize, uint32_t deflate)
     {
-        H5::Exception::dontPrint();
+        KEAStackPrintState();
         
         H5::H5File *keaImgH5File = nullptr;
         
@@ -3053,7 +3145,7 @@ namespace kealib{
     
     H5::H5File* KEAImageIO::openKeaH5RW(const std::string &fileName, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize)
     {
-        H5::Exception::dontPrint();
+        KEAStackPrintState();
         
         H5::H5File *keaImgH5File = nullptr;
         try 
@@ -3097,7 +3189,7 @@ namespace kealib{
     
     H5::H5File* KEAImageIO::openKeaH5RDOnly(const std::string &fileName, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize)
     {
-        H5::Exception::dontPrint();
+        KEAStackPrintState();
         
         H5::H5File *keaImgH5File = nullptr;
         try 
@@ -3142,7 +3234,7 @@ namespace kealib{
     bool KEAImageIO::isKEAImage(const std::string &fileName)
     {
         bool keaImageFound = false;
-        H5::Exception::dontPrint();
+        KEAStackPrintState();
         
         try 
         {
@@ -3217,6 +3309,8 @@ namespace kealib{
 
     void KEAImageIO::addImageBand(const KEADataType dataType, const std::string &bandDescrip, const uint32_t imageBlockSize, const uint32_t attBlockSize, const uint32_t deflate)
     {
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");
@@ -3237,7 +3331,8 @@ namespace kealib{
     
     void KEAImageIO::removeImageBand(const uint32_t bandIndex)
     {
-
+        std::lock_guard<std::recursive_mutex>(*this->m_mutex); 
+        KEAStackPrintState();
         if(!this->fileOpen)
         {
             throw KEAIOException("Image was not open.");


### PR DESCRIPTION
This PR is an attempt to solve 2 problems:
1. kealib is not thread safe
2. when calling kealib on other threads than the one you used to open/create the file causes hdf5 to be very verbose

More detail below.

**kealib is not thread safe**

Firstly, the C++ hdf5 bindings aren't thread safe. Secondly, kealib has internal class members that are accessed/modified without appropriate locking. The GDAL driver has had some work to ensure its internal members are protected, but this hasn't been pushed down in to kealib. Doing so will guard against people who are linking to kealib directly (like the Python bindings) and also from GDAL but from a method that has no locking (because there are no internal members used).

This is addressed using `std::recursive_mutex` everywhere. I've gone for this because it is safest, especially since most things call into the hdf5 C++ bindings. There was a problem with the RAT classes needing to see the same mutex as KEAImageIO (using the C++ bindings) so I've used `std::shared_ptr` to allow them to share a mutex (and a new base class for both to hold this).

**hdf5 error trace**

kealib calls `Exception::dontPrint` on file creation and open. `Exception::dontPrint` only applies per-thread though. So if you call back into kealib from another thread you may well get a stack trace when it is looking up something that isn't in the file (ie NODATA). 

This is addressed by the RAII style `KEAStackPrintState` class everywhere hdf5 is called that saves the trace printing state and restores it at function end. This should reduce the likelihood of conflict with another library that is calling hdf5.

This will break ABI compatibility with 1.5.x

@petebunting any thoughts?

cc:  @neilflood, @petescarth