### PR TITLE
flush overviews in GDAL driver

### DIFF
--- a/gdal/keaoverview.cpp
+++ b/gdal/keaoverview.cpp
@@ -45,7 +45,8 @@ KEAOverview::KEAOverview(KEADataset *pDataset, int nSrcBand, GDALAccess eAccess,
 
 KEAOverview::~KEAOverview()
 {
-
+    // according to the docs, this is required
+    this->FlushCache();
 }
 
 // overridden implementation - calls readFromOverview instead


### PR DESCRIPTION
Appears to solve problem @neilflood reported where overviews aren't written properly.