### PR TITLE
fix memory leaks, close dataset for neighbours

### DIFF
--- a/python/build_neighbours.py
+++ b/python/build_neighbours.py
@@ -99,7 +99,7 @@ def buildNeighbours(ds, band, tilesize=DFLT_TILESIZE, eightway=False):
     size = extrat.getSize(ds, band)
     histogram = extrat.getField(ds, band, fieldInfo, 0, size)
     
-    # will through exception if not set, but we need a nodata otherwise
+    # will throw exception if not set, but we need a nodata otherwise
     # we can't do a read with margin
     nodata = extrat.getNoDataValue(ds, band)
     

--- a/python/extrat.cpp
+++ b/python/extrat.cpp
@@ -42,6 +42,7 @@
 #include "libkea/KEAImageIO.h"
 
 #ifdef WIN32
+    #define NOMINMAX  // otherwise std::min won't work
     #include <Windows.h>
     #define DEFAULT_GDAL "gdal.dll"
 #else

--- a/python/extrat.cpp
+++ b/python/extrat.cpp
@@ -865,6 +865,7 @@ pybind11::object getImageBlock(pybind11::object &dataset, uint32_t nBand,
 // represents a 'page' of the neighbours RAT. Generally contains PAGE_SIZE
 // entries, but may be less for the last page.
 // accumulates neighbours for that page and writes out when complete
+// Similar to Neil's RatPage in pyshepseg.tiling.
 class NeighbourPage
 {
 public:

--- a/src/libkea/KEAAttributeTableFile.cpp
+++ b/src/libkea/KEAAttributeTableFile.cpp
@@ -1345,8 +1345,8 @@ namespace kealib{
                     delete[] ((hsize_t*)neighbourVals[i].p);
                 }
             }
-            
-            
+            neighboursDataset->close();
+            delete neighboursDataset;
         }
         catch(const H5::Exception &e)
         {
@@ -2411,6 +2411,8 @@ namespace kealib{
     
     KEAAttributeTableFile::~KEAAttributeTableFile()
     {
+        // because we don't flush on each operation, let's do it here so any changes are written
+        keaImg->flush(H5F_SCOPE_GLOBAL);
     }
     
 }

--- a/src/libkea/KEAImageIO.cpp
+++ b/src/libkea/KEAImageIO.cpp
@@ -2966,7 +2966,7 @@ namespace kealib{
             throw KEAIOException(e.what());
         }
     }
-        
+
     H5::H5File* KEAImageIO::createKEAImage(const std::string &fileName, KEADataType dataType, uint32_t xSize, uint32_t ySize, uint32_t numImgBands, std::vector<std::string> *bandDescrips, KEAImageSpatialInfo * spatialInfo, uint32_t imageBlockSize, uint32_t attBlockSize, int mdcElmts, hsize_t rdccNElmts, hsize_t rdccNBytes, double rdccW0, hsize_t sieveBuf, hsize_t metaBlockSize, uint32_t deflate)
     {
         KEAStackPrintState printState;


### PR DESCRIPTION
A better fix than #71.

Turns out there were a bunch of memory leaks with the Python bindings (not deleting the RAT when finished). 

However, main problem was that the HDF5 dataset object was not closed for the neighbours by `KEAAttributeTableFile::setNeighbours`. It is for all the other column types. Perhaps having decent RAII style classes for doing this via HighFive or whatever will hopefully reduce the likelihood of this. 

Anyway, the result was the HDF5 file wasn't being closed when it should have. This was happening at the end of the script instead, scrambling other updates to the file that happened after setting the neighbours.

This is now much slower (but faster than #71). I'll work on improving that as part of this PR. 

ok @petebunting 
ping @petescarth @neilflood 